### PR TITLE
fix bug where interleaved kill and create lead to duplicate ids

### DIFF
--- a/src/entities.rs
+++ b/src/entities.rs
@@ -1,4 +1,6 @@
-use crate::{Entity, BitSetVec, create_bitset, BitSet, BITSET_SLICE_COUNT, BITSET_SIZE, EntityIterator};
+use crate::{
+    create_bitset, BitSet, BitSetVec, Entity, EntityIterator, BITSET_SIZE, BITSET_SLICE_COUNT,
+};
 
 /// Holds a list of alive entities.
 /// It also holds a list of entities that were recently killed, which allows
@@ -50,7 +52,7 @@ impl Entities {
             }
             self.alive.bit_set(i);
             if i >= self.max_id {
-                self.max_id = i;
+                self.max_id = i + 1;
                 self.has_deleted = false;
             }
             Entity::new(i as u32, self.generation[i])
@@ -128,5 +130,27 @@ mod tests {
         entities.clear_killed();
         assert_eq!(*entities.killed(), vec![]);
     }
-}
 
+    #[test]
+    fn test_interleaved_create_kill() {
+        let mut entities = Entities::default();
+
+        let e1 = entities.create();
+        assert_eq!(e1.index(), 0);
+        let e2 = entities.create();
+        assert_eq!(e2.index(), 1);
+        entities.kill(e1);
+        entities.kill(e2);
+        assert_eq!(entities.is_alive(e1), false);
+        assert_eq!(entities.is_alive(e2), false);
+
+        let e3 = entities.create();
+        assert_eq!(e3.index(), 2);
+        let e4 = entities.create();
+        assert_eq!(e4.index(), 3);
+        entities.kill(e3);
+        entities.kill(e4);
+        assert_eq!(entities.is_alive(e3), false);
+        assert_eq!(entities.is_alive(e4), false);
+    }
+}

--- a/src/entities.rs
+++ b/src/entities.rs
@@ -9,9 +9,9 @@ pub struct Entities {
     alive: BitSetVec,
     generation: Vec<u32>,
     killed: Vec<Entity>,
-    max_id: usize,
+    next_id: usize,
     /// helps to know if we should directly append after
-    /// max_id or if we should look through the bitset.
+    /// next_id or if we should look through the bitset.
     has_deleted: bool,
 }
 
@@ -21,7 +21,7 @@ impl Default for Entities {
             alive: create_bitset(),
             generation: vec![0u32; BITSET_SIZE],
             killed: vec![],
-            max_id: 0,
+            next_id: 0,
             has_deleted: false,
         }
     }
@@ -33,8 +33,8 @@ impl Entities {
     /// the killed entities.
     pub fn create(&mut self) -> Entity {
         if !self.has_deleted {
-            let i = self.max_id;
-            self.max_id += 1;
+            let i = self.next_id;
+            self.next_id += 1;
             self.alive.bit_set(i);
             Entity::new(i as u32, self.generation[i])
         } else {
@@ -51,8 +51,8 @@ impl Entities {
                 i += 1;
             }
             self.alive.bit_set(i);
-            if i >= self.max_id {
-                self.max_id = i + 1;
+            if i >= self.next_id {
+                self.next_id = i + 1;
                 self.has_deleted = false;
             }
             Entity::new(i as u32, self.generation[i])
@@ -92,7 +92,7 @@ impl Entities {
     pub fn iter_with_bitset<'a>(&'a self, bitset: std::rc::Rc<BitSetVec>) -> EntityIterator<'a> {
         EntityIterator {
             current_id: 0,
-            max_id: self.max_id,
+            next_id: self.next_id,
             entities: &self.alive,
             generations: &self.generation,
             bitset,

--- a/src/entity_iterator.rs
+++ b/src/entity_iterator.rs
@@ -1,9 +1,9 @@
-use crate::{BitSetVec, Entity, BitSet};
+use crate::{BitSet, BitSetVec, Entity};
 
 /// Iterator over entities using the provided bitset.
 pub struct EntityIterator<'a> {
     pub(crate) current_id: usize,
-    pub(crate) max_id: usize,
+    pub(crate) next_id: usize,
     pub(crate) entities: &'a BitSetVec,
     pub(crate) generations: &'a Vec<u32>,
     //pub(crate) bitset: &'a BitSetVec,
@@ -13,10 +13,10 @@ pub struct EntityIterator<'a> {
 impl<'a> Iterator for EntityIterator<'a> {
     type Item = Option<Entity>;
     fn next(&mut self) -> Option<Self::Item> {
-        while !self.bitset.bit_test(self.current_id) && self.current_id <= self.max_id {
+        while !self.bitset.bit_test(self.current_id) && self.current_id < self.next_id {
             self.current_id += 1;
         }
-        let ret = if self.current_id <= self.max_id {
+        let ret = if self.current_id < self.next_id {
             if self.entities.bit_test(self.current_id) {
                 Some(Some(Entity::new(
                     self.current_id as u32,


### PR DESCRIPTION
Noticed this due to a "upgrade" system transforming entities into new ones, so it'd delete X entities and create X entities, but only X - 1 would be remembered. 

For the test case, what would happen is that you'd observe the sequence:

```
Create 0
Create 1
Kill 0
Kill 1
Create 2
Create 2
```

This is due to return `i == max_id` in the first post-kill create, and then returning `max_id` in the second call. It also seems to me like `max_id` is more clearly `next_id` -- if you disagree I can drop that commit, but that realization helped diagnose this bug.